### PR TITLE
Updated Social Media Numbers

### DIFF
--- a/layouts/_default/sponsors.html
+++ b/layouts/_default/sponsors.html
@@ -167,8 +167,8 @@
                                 <i class="uil uil-youtube"></i> YouTube
                             </a>
                         </td>
-                        <td>3,056 subscribers <br>
-                            126,227+ views
+                        <td>3,580 subscribers <br>
+                            126,800+ views
                         </td>
                     </tr>
                     <tr>

--- a/layouts/_default/sponsors.html
+++ b/layouts/_default/sponsors.html
@@ -177,7 +177,7 @@
                                 <i class="fa fa-meetup"></i> Meetup
                             </a>
                         </td>
-                        <td>811 members</td>
+                        <td>830 members</td>
                     </tr>
                     <tr>
                         <td>

--- a/layouts/_default/sponsors.html
+++ b/layouts/_default/sponsors.html
@@ -185,7 +185,7 @@
                                 <i class="uil uil-github"></i> GitHub
                             </a>
                         </td>
-                        <td>9,100 stars</td>
+                        <td>9,200 stars</td>
                     </tr>
                 </tbody>
             </table>

--- a/layouts/_default/sponsors.html
+++ b/layouts/_default/sponsors.html
@@ -127,7 +127,7 @@
 
         <div class="social_reach_right">
             <table class="social_reach_table">
-                <caption><strong>PyMC Social Media Reach (<em>Updated: 2023-02-23</em> )</strong></caption>
+                <caption><strong>PyMC Social Media Reach (<em>Updated: 2025-07-29</em> )</strong></caption>
                 <thead>
                     <tr>
                         <th>Platform</th>
@@ -141,17 +141,17 @@
                                 <i class="uil uil-comment-alt-lines"></i> Discourse Q&A/Discussion
                             </a>
                         </td>
-                        <td>33,200+ posts <br>
-                            3,100 users
+                        <td>50,000+ posts <br>
+                            4,235 users
                         </td>
                     </tr>
                     <tr>
                         <td>
                             <a href="{{ .Site.Author.twitter }}" target="_blank">
-                                <i class="uil uil-twitter"></i> Twitter
+                                <i class="uil uil-twitter"></i> Twitter / X
                             </a>
                         </td>
-                        <td>5012 followers</td>
+                        <td>5186 followers</td>
                     </tr>
                     <tr>
                         <td>
@@ -159,7 +159,7 @@
                                 <i class="uil uil-linkedin-alt"></i> LinkedIn
                             </a>
                         </td>
-                        <td>1221 followers</td>
+                        <td>3,000 followers</td>
                     </tr>
                     <tr>
                         <td>
@@ -167,8 +167,8 @@
                                 <i class="uil uil-youtube"></i> YouTube
                             </a>
                         </td>
-                        <td>1,750 subscribers <br>
-                            57,650+ views
+                        <td>3,056 subscribers <br>
+                            126,227+ views
                         </td>
                     </tr>
                     <tr>
@@ -177,7 +177,7 @@
                                 <i class="fa fa-meetup"></i> Meetup
                             </a>
                         </td>
-                        <td>419 members</td>
+                        <td>811 members</td>
                     </tr>
                     <tr>
                         <td>
@@ -185,7 +185,7 @@
                                 <i class="uil uil-github"></i> GitHub
                             </a>
                         </td>
-                        <td>7300 stars</td>
+                        <td>9,100 stars</td>
                     </tr>
                 </tbody>
             </table>

--- a/layouts/_default/sponsors.html
+++ b/layouts/_default/sponsors.html
@@ -159,7 +159,7 @@
                                 <i class="uil uil-linkedin-alt"></i> LinkedIn
                             </a>
                         </td>
-                        <td>3,000 followers</td>
+                        <td>3,500 followers</td>
                     </tr>
                     <tr>
                         <td>

--- a/layouts/_default/sponsors.html
+++ b/layouts/_default/sponsors.html
@@ -127,7 +127,7 @@
 
         <div class="social_reach_right">
             <table class="social_reach_table">
-                <caption><strong>PyMC Social Media Reach (<em>Updated: 2025-07-29</em> )</strong></caption>
+                <caption><strong>PyMC Social Media Reach (<em>Updated: 2025-08-08</em> )</strong></caption>
                 <thead>
                     <tr>
                         <th>Platform</th>


### PR DESCRIPTION
Towards #151

This PR updates the `layouts/_default/sponsor.html` layout file. 
All the social media numbers are updated as per today's date (29/07/2025).